### PR TITLE
Visualization improvements and cifti tools

### DIFF
--- a/figure_handle_update_test.ipynb
+++ b/figure_handle_update_test.ipynb
@@ -7,17 +7,17 @@
     "ExecuteTime": {
      "end_time": "2017-09-07T23:06:36.271667Z",
      "start_time": "2017-09-07T23:06:32.589796Z"
-    },
-    "collapsed": true
+    }
    },
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "from niwidgets import NiftiWidget"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2017-09-07T23:06:37.103129Z",
@@ -28,7 +28,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5aad6094a9da47e8b65417a47bdccf7f",
+       "model_id": "bea47ec3870b4fb0a9887c62d4489c00",
        "version_major": 2,
        "version_minor": 0
       },
@@ -41,17 +41,15 @@
     }
    ],
    "source": [
-    "filename = './niwidgets/data/T1.nii.gz'\n",
+    "filename = '/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz'\n",
     "my_widget = NiftiWidget(filename)\n",
-    "my_widget.nifti_plotter()"
+    "a = my_widget.nifti_plotter();"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -72,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   },
   "toc": {
    "nav_menu": {},

--- a/figure_handle_update_test.ipynb
+++ b/figure_handle_update_test.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-09-07T23:06:36.271667Z",
+     "start_time": "2017-09-07T23:06:32.589796Z"
+    },
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from niwidgets import NiftiWidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2017-09-07T23:06:37.103129Z",
+     "start_time": "2017-09-07T23:06:36.275520Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5aad6094a9da47e8b65417a47bdccf7f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "filename = './niwidgets/data/T1.nii.gz'\n",
+    "my_widget = NiftiWidget(filename)\n",
+    "my_widget.nifti_plotter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  },
+  "toc": {
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": "block",
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/niwidgets/ciftitools.py
+++ b/niwidgets/ciftitools.py
@@ -1,0 +1,268 @@
+from __future__ import print_function
+import os, sys, time
+import numpy as np
+import nibabel as nb
+
+#class CiftiTools:
+#    '''
+#    Tools to manipulate cifti files and prepare them for display.
+#    '''
+#
+#    def __init__(self, filename):
+#        if not os.path.exists(filename):
+#            raise ValueError('File {}does not exist, please provide a valid path.'.format(filename))
+#        self.filename=filename
+
+def cread(infile):
+    '''
+    Loads a cifti file and stores as five objects: data array, cifti header, nifti header, extra metadata, filemap
+    Example call:
+        cd,ch,cn,cx,cf=cread(path_to_cifti)
+    
+    Parameters
+    ----------
+    infile: str, Cifti2Image
+        string containing path to cifti file or an already loaded cifti object
+    '''
+    if isinstance(infile,nb.cifti2.cifti2.Cifti2Image):
+        try:
+            cin=infile
+        except:
+            raise ValueError('Please provide a valid cifti file.')
+    elif isinstance(infile,str):
+        if not os.path.exists(infile):
+            raise ValueError('File does not exist, please provide a valid path to a cifti file.')
+        try:
+            cin=nb.load(infile) # NB causes apparently benign warning as of NiBabel version 2.2.0dev
+        except:
+            raise ValueError('Please provide a valid cifti file.')
+    cdata=np.asarray(cin.get_data()).copy()
+    chead=cin.header.copy()
+    cnhdr=cin.nifti_header.copy()
+    cxtra=cin.extra.copy()
+    cfmap=cin.file_map.copy()
+    return cdata,chead,cnhdr,cxtra,cfmap
+
+def csave(filename,cdata,chead,cnhdr=None,cxtra=None,cfmap=None,returnImg=False):
+    '''
+    Saves a cifti image from a collection of cifti substructures to file.
+    
+    Parameters
+    ----------
+    filename: str
+        string containing output file path
+    cdata: numpy ndarray
+        array containing data to be saved, can be 1D (single timepoint) or 2D (timeseries)
+    chead: Cifti2Header
+        cifti header data, generally extracted from a previously read cifti file
+    cnhdr: Nifti2Header (optional)
+        nifti header data, also generally extracted from a previously read cifti file
+    cxtra: dict (optional)
+        extra cifti metadata, generally empty
+    cfmap: dict (optional)
+        file map, generally contains the string 'image'
+    returnImg: bool
+        optionally return the compiled cifti object
+    '''
+    cout=nb.Cifti2Image(dataobj=cdata,header=chead,nifti_header=cnhdr, extra=cxtra, file_map=cfmap)
+    cout.to_filename(filename)
+    if returnImg is True:
+        return cout
+
+def clthresh(data,thresh,setTo=0):
+    '''
+    Set all values below threshold for a cifti file to a given value (default 0).
+    
+    Parameters
+    ----------
+    data: numpy ndarray
+        array containing data to be thresholded
+    thresh: float
+        Threshold value (exclusive)
+    setTo: float
+        Value to which voxels/vertices are set if below the threshold, default 0
+    '''
+    # 
+    lthr_data=data.copy()
+    lthr_data[lthr_data<thresh]=setTo
+    return lthr_data
+
+def cuthresh(data,thresh,setto=0):
+    '''
+    Set all values above threshold for a cifti file to a given value (default 0).
+    
+    Parameters
+    ----------
+    data: numpy ndarray
+        array containing data to be thresholded
+    thresh: float
+        Threshold value (exclusive)
+    setTo: float
+        Value to which voxels/vertices are set if above the threshold, default 0
+    '''
+    # set all values above threshold to a given value (default 0)
+    uthr_data=data.copy()
+    uthr_data[uthr_data>thresh]=setto
+    return uthr_data
+
+def cmask(target,mask):
+    '''
+    Masks target cifti file with non-zero values of mask cifti file
+    
+    Parameters
+    ----------
+    target: numpy ndarray
+        numpy array containing cifti data to be masked
+    mask: numpy ndarray
+        numpy array containing cifti data to use as mask. Can be 1D or 2D, must match target spatial dimensions.
+    '''
+    masked_data=target.copy()
+    if target.shape != mask.shape:
+        mask=np.tile(mask,(target.shape[0],1))
+    masked_data[mask==0]=0 # NB could be sped up by using a data dictionary, not currently high-priority
+    return masked_data
+
+def cinfo(infile):
+    '''
+    Returns information about input cifti header
+    
+    Parameters
+    ----------
+    infile: str, Cifti2Image
+        string containing path to cifti file or an already loaded cifti object
+    verbose: bool
+        report relatively esoteric cifti header info
+    '''
+    if isinstance(infile,nb.cifti2.cifti2.Cifti2Header):
+        ch=infile
+    elif isinstance(infile,nb.cifti2.cifti2.Cifti2Image):
+        cin=infile
+        cd,ch,cn,cx,cf=cread(infile)
+    elif isinstance(infile,str):
+        if not os.path.exists(infile):
+            raise ValueError('File does not exist, please provide a valid path to a cifti file.')
+        try:
+            cd,ch,cn,cx,cf=cread(infile)
+        except:
+            raise ValueError('Please provide a valid cifti file.')
+    ch0=ch.get_index_map(0)
+    ch1=ch.get_index_map(1)
+    if ch.get_index_map(0).indices_map_to_data_type=='CIFTI_INDEX_TYPE_SERIES': # support for other cifti types pending
+        print('cifti data dype = fMRI timeseries')
+        me=ch1.volume.transformation_matrix_voxel_indices_ijk_to_xyz.meter_exponent
+        if me==-3:
+            units='MM'
+        else:
+            units='x10^{e} M'.format(e=me)
+        print('Xdim = {x} {u} x {xx}'.format(
+            x=np.abs(ch1.volume.transformation_matrix_voxel_indices_ijk_to_xyz.matrix[0,0]),
+            u=units,
+            xx=ch1.volume.volume_dimensions[0]))
+        print('Ydim = {y} {u} x {yy}'.format(
+            y=np.abs(ch1.volume.transformation_matrix_voxel_indices_ijk_to_xyz.matrix[1,1]),
+            u=units,
+            yy=ch1.volume.volume_dimensions[1]))
+        print('Zdim = {z} {u} x {zz}'.format(
+            z=np.abs(ch1.volume.transformation_matrix_voxel_indices_ijk_to_xyz.matrix[2,2]),
+            u=units,
+            zz=ch1.volume.volume_dimensions[2]))
+        print('Tdim = {y} {z} x {t}'.format(
+            y=ch.get_index_map(0).series_step,
+            z=ch.get_index_map(0).series_unit,
+            t=ch.get_index_map(0).number_of_series_points))
+    disp=[]
+    voxels=0
+    print('INDEX      OFFSET     SIZE       STRUCTURE')
+    for idx, bm in enumerate(ch1.brain_models):
+        disp.append([idx,bm.index_offset,bm.index_count,bm.brain_structure])
+        if bm.model_type=='CIFTI_MODEL_TYPE_VOXELS':
+            voxels=voxels+bm.index_count
+    col_width = max(len(str(word)) for row in disp for word in row) + 2  # padding
+    for row in disp:
+        print("{: <10} {: <10} {: <10} {: <20}".format(*row))
+    print('total left cortex vertices = {lv} of {lt}'.format(
+        lv=list(ch1.brain_models)[0].index_count,
+        lt=list(ch1.brain_models)[0].surface_number_of_vertices))
+    print('total right cortex vertices = {rv} of {rt}'.format(
+        rv=list(ch1.brain_models)[1].index_count,
+        rt=list(ch1.brain_models)[1].surface_number_of_vertices))
+    print('total subcortical voxels = {v}'.format(v=voxels))
+    print('total data points = {total}'.format(
+        total=list(ch1.brain_models)[0].index_count+list(ch1.brain_models)[1].index_count+voxels))
+
+def cvoxels(header,MNI=True,trim=False):
+    '''
+    Returns array where each element is an array of coordinates for a particular cifti brain structure.
+    Coordinates can be voxel indices (i,j,k) or MNI coordinates (x,y,z; default).
+    
+    Parameters
+    ----------
+    header: Cifti2Header
+        cifti header object containing the voxel index mapping and list of brain structures
+    MNI: bool
+        True returns MNI coordinates, False returns voxel indices, default=True
+    trim: bool
+        removes array elements corresponding to cortical surfaces, default=False
+    '''
+    if not isinstance(header,nb.cifti2.cifti2.Cifti2Header):
+        raise ValueError('Please provide a valid cifti header.')
+
+    ch1=header.get_index_map(1)
+    voxarray=[]
+    if MNI is True:
+        from nibabel.affines import apply_affine
+        warp=ch1.volume.transformation_matrix_voxel_indices_ijk_to_xyz.matrix
+    for idx, bm in enumerate(ch1.brain_models):
+        if bm.model_type=='CIFTI_MODEL_TYPE_VOXELS':
+            if MNI is False:
+                voxarray.append(np.asarray(bm.voxel_indices_ijk))
+            else:
+                voxarray.append(apply_affine(warp,bm.voxel_indices_ijk))
+        else:
+            if trim is False:
+                voxarray.append([[],[],[]])
+    return np.asarray(voxarray)
+
+def csplit(incifti,gii=False):
+    '''
+    Split cifti overlay into separate left surface, right surface, and subcortical voxel arrays.
+    
+    Parameters
+    ----------
+    incifti: str, Cifti2Image
+        string containing path to cifti file or an already loaded cifti object
+    gii: bool
+        returns surfaces as GiftiImage objects, default=False
+    '''
+    if isinstance(incifti,nb.cifti2.cifti2.Cifti2Image):
+        cd=np.asarray(incifti.get_data()).copy()
+        ch=incifti.header.copy()
+    elif isinstance(incifti,str):
+        if not os.path.exists(incifti):
+            raise ValueError('File does not exist, please provide a valid path to a cifti file.')
+        try:
+            cd,ch,cn,cx,cf=cread(incifti)
+        except:
+            raise ValueError('Please provide a valid cifti file.')   
+    mim = ch.matrix[1]
+    bm1 = list(mim.brain_models)[0]
+    bm2 = list(mim.brain_models)[1]
+    lidx = list(bm1.vertex_indices)
+    ridx = [bm1.surface_number_of_vertices + val for val in bm2.vertex_indices]
+    bidx = np.concatenate((lidx, ridx))
+    # split cifti overlay into left surface, right surface, and subcortical volume
+    clh=cd[:,0:len(lidx)]
+    crh=cd[:,len(lidx):len(lidx)+len(ridx)+1]
+    csc=cd[:,len(lidx)+len(ridx)+1:cd.shape[1]]
+    if gii is True:
+        glh=nb.gifti.gifti.GiftiImage()
+        grh=nb.gifti.gifti.GiftiImage()
+        glh.add_gifti_data_array(nb.gifti.gifti.GiftiDataArray(clh))
+        grh.add_gifti_data_array(nb.gifti.gifti.GiftiDataArray(crh))
+        left=glh
+        right=grh
+    else:
+        left=clh
+        right=crh
+    sub=csc # option for .nii format subcortex data pending
+    return left, right, sub

--- a/niwidgets/niwidget.py
+++ b/niwidgets/niwidget.py
@@ -7,7 +7,6 @@ import os
 import inspect
 import scipy.ndimage
 
-
 class NiftiWidget:
     """
     Turns .nii files into interactive plots using ipywidgets.

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -3,6 +3,7 @@ import nibabel as nb
 import matplotlib.pyplot as plt
 import numpy as np
 from ipywidgets import interact, fixed, IntSlider
+from ipyvolume import gcf
 import ipyvolume.pylab as p3
 import ipyvolume.widgets as ipv
 import os
@@ -18,54 +19,29 @@ class SurfaceWidget:
         self.fig = None
 
     def _init_figure(self, x, y, z, triangles, figsize, figlims):
-        #fig = gcf()
-
-        fig = p3.figure(width=figsize[0], height=figsize[1])
-        fig.camera_fov = 1
-        fig.style = {'axes': {'color': 'black',
+        self.fig = p3.figure(width=figsize[0], height=figsize[1])
+        self.fig.camera_fov = 1
+        self.fig.style = {'axes': {'color': 'black',
                      'label': {'color': 'black'},
                      'ticklabel': {'color': 'black'},
                      'visible': False},
                      'background-color': 'white',
                      'box': {'visible': False}}
-        fig.xlim = (figlims[0][0], figlims[0][1])
-        fig.ylim = (figlims[1][0], figlims[1][1])
-        fig.zlim = (figlims[2][0], figlims[2][1])
+        self.fig.xlim = (figlims[0][0], figlims[0][1])
+        self.fig.ylim = (figlims[1][0], figlims[1][1])
+        self.fig.zlim = (figlims[2][0], figlims[2][1])
 
         #p3.figure()
         # we draw the tetrahedron
-        p3.plot_trisurf(x, y, z, triangles=triangles,
-                               color=np.ones((len(x),3)))
+        p3.plot_trisurf(x, y, z, triangles=triangles, color=np.ones((len(x),3)))
         p3.show()
-
-        self.fig = p3.gcf()
-
-        '''
-        if triangles is not None:
-            triangles = np.array(triangles).astype(dtype=np.uint32)
-
-        mesh = p3.Mesh(x=x, y=y, z=z, triangles=triangles,
-                        lines=None, color=np.ones([len(x),3]),
-                        u=u, v=v, texture=texture)
-
-        # can comment out if there are problems
-        mesh._grow_limits(np.array(x).reshape(-1), np.array(y).reshape(-1), np.array(z).reshape(-1))
-        '''
-
-        #self.meshes.append(mesh)
 
     def _plot_surface(self, x, y, z, triangles,
                       overlays=None, frame=0,
                       colormap='summer',
                       figsize=np.array([600,600]),
                       figlims=np.array([[-100,100],[-100,100],[-100,100]])):
-        '''
-        if self.meshes is None:
-            self.meshes = []
-            self._init_figure(x, y, z, triangles, figsize, figlims)
-        '''
         if self.fig is None:
-            self.fig = []
             self._init_figure(x, y, z, triangles, figsize, figlims)
 
         # overlays is a 2D matrix
@@ -73,9 +49,7 @@ class SurfaceWidget:
         my_color = plt.cm.get_cmap(colormap)
         activation = overlays[:,frame]
         colors=my_color((activation-min(activation))/(max(activation)-min(activation)))
-
         self.fig.meshes[0].color = colors[:,:3]
-        #p3.show()
 
     def surface_plotter(self, colormap=None,
                         figsize=np.array([600,600]),
@@ -117,10 +91,6 @@ class SurfaceWidget:
                 x, y, z = vertex_spatial.T
             except:
                 raise ValueError('Please provide a valid gifti file.')
-
-        print(x.shape)
-        print(y.shape)
-        print(z.shape)
 
         if isinstance(self.overlayfiles,list):
             max_frame = len(self.overlayfiles)-1

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -1,23 +1,153 @@
 from __future__ import print_function
-import nibabel as nib
+import nibabel as nb
 import matplotlib.pyplot as plt
 import numpy as np
-from ipywidgets import interact, fixed
+from ipywidgets import interact, fixed, IntSlider
+import ipyvolume.pylab as p3
+import ipyvolume.widgets as ipv
 import os
 import inspect
 import scipy.ndimage
 
+
 class SurfaceWidget:
     def __init__(self, meshfile, overlayfiles):
-        if not os.path.isfile(meshfile):
-            # for Python3 should have FileNotFoundError here
-            raise IOError('file {} not found'.format(meshfile))
-        for overlayfile in overlayfiles:
-            if not os.path.isfile(overlayfile):
-                # for Python3 should have FileNotFoundError here
-                raise IOError('file {} not found'.format(overlayfile))
         self.meshfile = meshfile
         self.overlayfiles = overlayfiles
-        self.image_handles = None
+        self.meshes = None
 
-    def 
+    def _init_figure(self, x, y, z, triangles, figsize, figlims):
+        #fig = gcf()
+
+        fig = p3.figure(width=figsize[0], height=figsize[1])
+        fig.camera_fov = 1
+        fig.style = {'axes': {'color': 'black',
+                     'label': {'color': 'black'},
+                     'ticklabel': {'color': 'black'},
+                     'visible': False},
+                     'background-color': 'white',
+                     'box': {'visible': False}}
+        fig.xlim = (figlims[0][0], figlims[0][1])
+        fig.ylim = (figlims[1][0], figlims[1][1])
+        fig.zlim = (figlims[2][0], figlims[2][1])
+
+        #p3.figure()
+        # we draw the tetrahedron
+        #mesh = p3.plot_trisurf(x, y, z, triangles=triangles, color='orange')
+
+        if triangles is not None:
+            triangles = np.array(triangles).astype(dtype=np.uint32)
+
+        mesh = p3.Mesh(x=x, y=y, z=z, triangles=triangles,
+                        lines=None, color=np.ones([len(x),3]),
+                        u=u, v=v, texture=texture)
+
+        # can comment out if there are problems
+        mesh._grow_limits(np.array(x).reshape(-1), np.array(y).reshape(-1), np.array(z).reshape(-1))
+
+
+        self.meshes.append(mesh)
+
+    def _plot_surface(self, x, y, z, triangles,
+                      overlays=None, frame=0,
+                      colormap='summer',
+                      figsize=np.array([600,600]),
+                      figlims=np.array([[-100,100],[-100,100],[-100,100]])):
+        if self.meshes is None:
+            self.meshes = []
+            self._init_figure(x, y, z, triangles, figsize, figlims)
+
+        # overlays is a 2D matrix
+        # with 2nd dimension corresponding to (time) frame
+        my_color = plt.cm.get_cmap(colormap)
+        activation = overlays[:,frame]
+        colors=my_color((activation-min(activation))/(max(activation)-min(activation)))
+        self.meshes[0].color = colors
+
+    def surface_plotter(self, colormap=None,
+                        figsize=np.array([600,600]),
+                        figlims=np.array([[-100,100],[-100,100],[-100,100]]),
+                        **kwargs):
+        # set default colormap options & add them to the kwargs
+        if colormap is None:
+            kwargs['colormap'] = ['viridis'] + \
+                sorted(m for m in plt.cm.datad if not m.endswith("_r"))
+        elif type(colormap) is str:
+            # fix cmap if only one given
+            kwargs['colormap'] = fixed(colormap)
+
+        kwargs['figsize'] = fixed(figsize)
+        kwargs['figlims'] = fixed(figlims)
+
+
+        if isinstance(self.meshfile,str):
+            if not os.path.exists(self.meshfile):
+                error('File does not exist, please provide a valid file path to a gifti or FreeSurfer file.')
+            filename, file_extension = os.path.splitext(self.meshfile)
+            if file_extension is '.gii':
+                mesh = nb.load(self.meshfile)
+                try:
+                    vertex_spatial=mesh.darrays[0].data
+                    vertex_edges=mesh.darrays[1].data
+                    x, y, z = vertex_spatial.T
+                except:
+                    raise ValueError('Please provide a valid gifti file.')
+            else:
+                fsgeometry = nb.freesurfer.read_geometry(mesh)
+                x,y,z = fsgeometry[0].T
+                vertex_edges=fsgeometry[1]
+
+        if isinstance(self.meshfile,nb.gifti.gifti.GiftiImage):
+            try:
+                vertex_spatial=self.meshfile.darrays[0].data
+                vertex_edges=self.meshfile.darrays[1].data
+                x, y, z = vertex_spatial.T
+            except:
+                raise ValueError('Please provide a valid gifti file.')
+
+        print(x.shape)
+        print(y.shape)
+        print(z.shape)
+
+        if isinstance(self.overlayfiles,list):
+            max_frame = len(self.overlayfiles)-1
+        else:
+            max_frame = 0
+            self.overlayfiles = [self.overlayfiles] # hack
+
+        overlays = np.zeros((len(x),len(self.overlayfiles)))
+        for ii, overlayfile in enumerate(self.overlayfiles):
+            if isinstance(overlayfile,str):
+                if not os.path.exists(overlayfile):
+                    error('File does not exist, please provide a valid file path to a gifti or FreeSurfer file.')
+                filename, file_extension = os.path.splitext(overlayfile)
+
+                if file_extension is '.gii':
+                    overlay = nb.load(overlayfile)
+                    try:
+                        overlays[:,ii]=overlay.darrays[0].data
+                    except:
+                        raise ValueError('Please provide a valid gifti file')
+                elif (file_extension in ('.annot','')):
+                    annot = nb.freesurfer.read_annot(overlayfile)
+                    overlays[:,ii] = annot[0]
+                elif (file_extension in ('.curv','.thickness','.sulc')):
+                    overlays[:,ii] = nb.freesurfer.read_morph_data(overlayfile)
+
+            if isinstance(overlayfile,nb.gifti.gifti.GiftiImage):
+                try:
+                    overlays[:,ii]=overlayfile.darrays[0].data
+                except:
+                    raise ValueError('Please provide a valid gifti file')
+
+        kwargs['triangles'] = fixed(vertex_edges)
+        kwargs['x'] = fixed(x)
+        kwargs['y'] = fixed(y)
+        kwargs['z'] = fixed(z)
+        kwargs['overlays'] = fixed(overlays)
+
+        interact(self._plot_surface,
+                 frame=IntSlider(default=0,
+                                 min=0,
+                                 max=max_frame),
+                 **kwargs)

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -14,7 +14,8 @@ class SurfaceWidget:
     def __init__(self, meshfile, overlayfiles):
         self.meshfile = meshfile
         self.overlayfiles = overlayfiles
-        self.meshes = None
+        #self.meshes = None
+        self.fig = None
 
     def _init_figure(self, x, y, z, triangles, figsize, figlims):
         #fig = gcf()
@@ -31,10 +32,13 @@ class SurfaceWidget:
         fig.ylim = (figlims[1][0], figlims[1][1])
         fig.zlim = (figlims[2][0], figlims[2][1])
 
-        p3.figure()
+        #p3.figure()
         # we draw the tetrahedron
-        mesh = p3.plot_trisurf(x, y, z, triangles=triangles,
+        p3.plot_trisurf(x, y, z, triangles=triangles,
                                color=np.ones((len(x),3)))
+        p3.show()
+
+        self.fig = p3.gcf()
 
         '''
         if triangles is not None:
@@ -48,15 +52,20 @@ class SurfaceWidget:
         mesh._grow_limits(np.array(x).reshape(-1), np.array(y).reshape(-1), np.array(z).reshape(-1))
         '''
 
-        self.meshes.append(mesh)
+        #self.meshes.append(mesh)
 
     def _plot_surface(self, x, y, z, triangles,
                       overlays=None, frame=0,
                       colormap='summer',
                       figsize=np.array([600,600]),
                       figlims=np.array([[-100,100],[-100,100],[-100,100]])):
+        '''
         if self.meshes is None:
             self.meshes = []
+            self._init_figure(x, y, z, triangles, figsize, figlims)
+        '''
+        if self.fig is None:
+            self.fig = []
             self._init_figure(x, y, z, triangles, figsize, figlims)
 
         # overlays is a 2D matrix
@@ -64,9 +73,9 @@ class SurfaceWidget:
         my_color = plt.cm.get_cmap(colormap)
         activation = overlays[:,frame]
         colors=my_color((activation-min(activation))/(max(activation)-min(activation)))
-        print(colors)
-        self.meshes[0].color = colors[:,:3]
-        p3.show()
+
+        self.fig.meshes[0].color = colors[:,:3]
+        #p3.show()
 
     def surface_plotter(self, colormap=None,
                         figsize=np.array([600,600]),

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import nibabel as nib
+import matplotlib.pyplot as plt
+import numpy as np
+from ipywidgets import interact, fixed
+import os
+import inspect
+import scipy.ndimage
+
+class SurfaceWidget:
+    def __init__(self, meshfile, overlayfiles):
+        if not os.path.isfile(meshfile):
+            # for Python3 should have FileNotFoundError here
+            raise IOError('file {} not found'.format(meshfile))
+        for overlayfile in overlayfiles:
+            if not os.path.isfile(overlayfile):
+                # for Python3 should have FileNotFoundError here
+                raise IOError('file {} not found'.format(overlayfile))
+        self.meshfile = meshfile
+        self.overlayfiles = overlayfiles
+        self.image_handles = None
+
+    def 

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -31,10 +31,12 @@ class SurfaceWidget:
         fig.ylim = (figlims[1][0], figlims[1][1])
         fig.zlim = (figlims[2][0], figlims[2][1])
 
-        #p3.figure()
+        p3.figure()
         # we draw the tetrahedron
-        #mesh = p3.plot_trisurf(x, y, z, triangles=triangles, color='orange')
+        mesh = p3.plot_trisurf(x, y, z, triangles=triangles,
+                               color=np.ones((len(x),3)))
 
+        '''
         if triangles is not None:
             triangles = np.array(triangles).astype(dtype=np.uint32)
 
@@ -44,7 +46,7 @@ class SurfaceWidget:
 
         # can comment out if there are problems
         mesh._grow_limits(np.array(x).reshape(-1), np.array(y).reshape(-1), np.array(z).reshape(-1))
-
+        '''
 
         self.meshes.append(mesh)
 
@@ -62,7 +64,9 @@ class SurfaceWidget:
         my_color = plt.cm.get_cmap(colormap)
         activation = overlays[:,frame]
         colors=my_color((activation-min(activation))/(max(activation)-min(activation)))
-        self.meshes[0].color = colors
+        print(colors)
+        self.meshes[0].color = colors[:,:3]
+        p3.show()
 
     def surface_plotter(self, colormap=None,
                         figsize=np.array([600,600]),

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ nibabel
 ipywidgets
 scikit-learn
 nilearn
+ipyvolume


### PR DESCRIPTION
Added ciftitools.py collection of functions for increased cifti support, developed at NeuroHackWeek 2017. Functions include:

cread: simplified loading of cifti files
csave: simplified saving of cifti files
clthresh: zero data below threshold
cuthresh: zero data above threshold
cmask: mask one cifti file with nonzero values from a second cifti file
cinfo: print useful cifti header metadata
cvoxels: return array of subcortical voxel coordinates
csplit: split cifti file into two gifti and one nifti file for e.g. display

These tools build on the nibabel cifti2 package.