### PR TITLE
Make the code for surface widgets faster & neater

### DIFF
--- a/Interactive Surface Visualization Demo.ipynb
+++ b/Interactive Surface Visualization Demo.ipynb
@@ -15,46 +15,17 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
     "import os\n",
     "import sys\n",
-    "from niwidgets import niwidget_surface"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# add an environment variable for where the notebook is e.g. by adding\n",
-    "# 'export NHW=$HOME/Desktop/niwidgets' to ~/.bashrc\n",
-    "data = os.environ['NHW'] "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "C:/Users/spn486/Desktop/NeuroHackWeek2017/nipy_niwidgets/niwidgets/data/example_surfaces/surf/lh.inflated\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Verify that your variable is pointing to the right place where you have decided to store your package data\n",
-    "print(data+'/niwidgets/data/example_surfaces/surf/lh.inflated')"
+    "from niwidgets import niwidget_surface\n",
+    "from niwidgets.exampledata import examplesurface, exampleoverlays\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -65,12 +36,27 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc9921f060584387b462f99f39833a13",
+       "model_id": "4546a2e205324411baac3eb08f7bf06e",
        "version_major": 2,
        "version_minor": 0
       },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>interactive</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
       "text/plain": [
-       "A Jupyter Widget"
+       "interactive(children=(IntSlider(value=0, description='frame', max=3), Dropdown(description='colormap', index=74, options=('viridis', 'Accent', 'Blues', 'BrBG', 'BuGn', 'BuPu', 'CMRmap', 'Dark2', 'GnBu', 'Greens', 'Greys', 'OrRd', 'Oranges', 'PRGn', 'Paired', 'Pastel1', 'Pastel2', 'PiYG', 'PuBu', 'PuBuGn', 'PuOr', 'PuRd', 'Purples', 'RdBu', 'RdGy', 'RdPu', 'RdYlBu', 'RdYlGn', 'Reds', 'Set1', 'Set2', 'Set3', 'Spectral', 'Vega10', 'Vega20', 'Vega20b', 'Vega20c', 'Wistia', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd', 'afmhot', 'autumn', 'binary', 'bone', 'brg', 'bwr', 'cool', 'coolwarm', 'copper', 'cubehelix', 'flag', 'gist_earth', 'gist_gray', 'gist_heat', 'gist_ncar', 'gist_rainbow', 'gist_stern', 'gist_yarg', 'gnuplot', 'gnuplot2', 'gray', 'hot', 'hsv', 'jet', 'nipy_spectral', 'ocean', 'pink', 'prism', 'rainbow', 'seismic', 'spectral', 'spring', 'summer', 'tab10', 'tab20', 'tab20b', 'tab20c', 'terrain', 'winter'), value='summer'), Output()), _dom_classes=('widget-interact',))"
       ]
      },
      "metadata": {},
@@ -79,12 +65,42 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e7ea0689de984f46b12eaf1fcbfa20c7",
+       "model_id": "fddb214fc89b4e7dad8bbdc5e855d0c2",
        "version_major": 2,
        "version_minor": 0
       },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>Figure</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
       "text/plain": [
-       "A Jupyter Widget"
+       "Figure(camera_center=[0.0, 0.0, 0.0], camera_fov=1.0, height=600, matrix_projection=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], matrix_world=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], meshes=[Mesh(color=array([[ 0. ,  0.5,  0.4],\n",
+       "       [ 0. ,  0.5,  0.4],\n",
+       "       [ 0. ,  0.5,  0.4],\n",
+       "       ..., \n",
+       "       [ 0. ,  0.5,  0.4],\n",
+       "       [ 0. ,  0.5,  0.4],\n",
+       "       [ 0. ,  0.5,  0.4]]), texture=None, triangles=array([[     0,      1,      3],\n",
+       "       [     4,      3,      1],\n",
+       "       [     0,     91,      1],\n",
+       "       ..., \n",
+       "       [123307, 123906, 123895],\n",
+       "       [123906, 123907, 123895],\n",
+       "       [123885, 124986, 124987]], dtype=uint32), x=array([ 18.7413578 ,  18.37849426,  19.00789833, ...,  17.78539658,\n",
+       "        17.8218174 ,  17.95105362]), y=array([-127.09669495, -127.08947754, -127.14855194, ...,   96.06409454,\n",
+       "         96.46263123,   96.3392868 ]), z=array([-48.42454529, -48.42292786, -48.9959259 , ...,  44.24810028,\n",
+       "        44.08300781,  44.18468475]))], style={'axes': {'color': 'black', 'label': {'color': 'black'}, 'ticklabel': {'color': 'black'}, 'visible': False}, 'background-color': 'white', 'box': {'visible': False}}, tf=None, width=600, xlim=[-100.0, 100.0], ylim=[-127.3917007446289, 127.3917007446289], zlim=[-100.0, 100.0])"
       ]
      },
      "metadata": {},
@@ -92,22 +108,17 @@
     }
    ],
    "source": [
-    "# example surface data from FreeSurfer:\n",
+    "my_widget = niwidget_surface.SurfaceWidget(examplesurface, exampleoverlays)\n",
     "\n",
-    "# inflated surface\n",
-    "meshfile_lh_inflated = data+'/niwidgets/data/example_surfaces/surf/lh.inflated'\n",
-    "\n",
-    "# curvature, cortical thickness and cortical area as well as a parcellation overlay file\n",
-    "overlayfiles_lh = [data+'/niwidgets/data/example_surfaces/surf/lh.thickness',\n",
-    "                   data+'/niwidgets/data/example_surfaces/surf/lh.curv',\n",
-    "                   data+'/niwidgets/data/example_surfaces/surf/lh.area',\n",
-    "                   data+'/niwidgets/data/example_surfaces/surf/lh.aparc.annot']\n",
-    "\n",
-    "# how to call the surface widget\n",
-    "sw = niwidget_surface.SurfaceWidget(meshfile=meshfile_lh_inflated,overlayfiles = overlayfiles_lh)\n",
-    "sw.surface_plotter()\n",
-    "sw.fig"
+    "my_widget.surface_plotter(showZeroes=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/niwidgets/exampledata.py
+++ b/niwidgets/exampledata.py
@@ -1,7 +1,17 @@
-import os
+"""Example files for use with niwidgets."""
+from pathlib import Path
 
-# define the example data
-root_dir, _ = os.path.split(__file__)
-exampleatlas = os.path.join(root_dir, 'data', 'cc400_roi_atlas.nii')
-examplezmap = os.path.join(root_dir, 'data', 'cognitive control_pFgA_z.nii.gz')
-examplet1 = os.path.join(root_dir, 'data', 'T1.nii.gz')
+
+root_dir = Path(__file__).parent / 'data'
+
+exampleatlas = root_dir / 'cc400_roi_atlas.nii'
+examplezmap = root_dir / 'cognitive control_pFgA_z.nii.gz'
+examplet1 = root_dir / 'T1.nii.gz'
+
+surface_dir = root_dir / 'example_surfaces'
+
+examplesurface = surface_dir / 'lh.inflated'
+exampleoverlays = [
+    surface_dir / f
+    for f in ('lh.area', 'lh.curv', 'lh.thickness', 'lh.aparc.annot')
+]

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -1,3 +1,4 @@
+"""A widget for surface-warped neuroimaging data."""
 from __future__ import print_function
 import nibabel as nb
 import matplotlib.pyplot as plt
@@ -10,31 +11,40 @@ import os
 
 class SurfaceWidget:
     def __init__(self, meshfile, overlayfiles):
-        '''
-            Create a surface widget
+    """Interact with brain surfaces right in the notebook."""
 
-            meshfile: file containing the
-                      (1) 3D coordinates of each vertex (V x 3 array, where V=#vertices)
-                      (2) triangle specifications (T x 3 array, where T=#triangles)
-                      Can be a FreeSurfer (i.e., lh.pial) or .gii mesh file
-            overlayfiles: overlay file containing the scalar value at each vertex (V x 1)
-                          Can be a FreeSurfer .annot, .thickness, .curv, .sulc; or .gii
-        '''
+        """
+        Create a surface widget.
+
+        meshfile: file containing the
+                  (1) 3D coordinates of each vertex (V x 3 array, where
+                  V=#vertices)
+                  (2) triangle specifications (T x 3 array, where T=#triangles)
+                  Can be a FreeSurfer (i.e., lh.pial) or .gii mesh file
+
+        overlayfiles: overlay file containing the scalar value at each vertex
+                      (V x 1)
+                      Can be a FreeSurfer .annot, .thickness, .curv, .sulc;
+                      or .gii
+
+        """
         self.meshfile = meshfile
         self.overlayfiles = overlayfiles
         #self.meshes = None
         self.fig = None
 
     def _init_figure(self, x, y, z, triangles, figsize, figlims):
-        '''
-            Initialize the figure by plotting the surface without any overlay.
-            x: x coordinates of vertices (V x 1 numpy array)
-            y: y coordinates of vertices (V x 1 numpy array)
-            z: z coordinates of vertices (V x 1 numpy array)
-            triangles: triangle specifications (T x 3 numpy array, where T=#triangles)
-            figsize: 2x1 list of integers
-            figlims: 3x2 list of integers
-        '''
+        """
+        Initialize the figure by plotting the surface without any overlay.
+
+        x: x coordinates of vertices (V x 1 numpy array)
+        y: y coordinates of vertices (V x 1 numpy array)
+        z: z coordinates of vertices (V x 1 numpy array)
+        triangles: triangle specifications (T x 3 numpy array, where
+        T=#triangles)
+        figsize: 2x1 list of integers
+        figlims: 3x2 list of integers
+        """
         self.fig = p3.figure(width=figsize[0], height=figsize[1])
         self.fig.camera_fov = 1
         self.fig.style = {'axes': {'color': 'black',
@@ -56,13 +66,15 @@ class SurfaceWidget:
                       colormap='summer',
                       figsize=np.array([600,600]),
                       figlims=np.array([[-100,100],[-100,100],[-100,100]])):
-        '''
-            Visualize/update the overlay by changing the color associated
-            with mesh vertices
+        """
+        Visualize/update the overlay.
 
-            overlays: V x F numpy array, where each column corresponds to a
-                      different overlay. F=#frames or #timepoints.
-        '''
+        This function changes the color associated with mesh vertices.
+
+        overlays: V x F numpy array, where each column corresponds to a
+                  different overlay. F=#frames or #timepoints.
+
+        """
         if self.fig is None:
             self._init_figure(x, y, z, triangles, figsize, figlims)
 
@@ -76,16 +88,6 @@ class SurfaceWidget:
         #return self.fig
 
     def zmask(surf,mask):
-        '''
-            Masks out vertices with intensity=0 from overlay. Also returns masked-out vertices.
-
-            Parameters
-            ----------
-            surf: gifti object
-                already loaded gifti object of target surface
-            mask: gifti object
-                already loaded gifti object of overlay with zeroes at vertices of no interest (e.g. medial wall)
-        '''
         keep=(mask.darrays[0].data!=0) # nonzero values of mask
         kill=(mask.darrays[0].data==0) # zero values of mask
         ikeep=[i for i, e in enumerate(keep) if e != 0] # indices of nonzero mask values
@@ -93,6 +95,27 @@ class SurfaceWidget:
         killdict={ii:1 for ii in ikill} # fun fact, iterating over a dictionary is ~exponentially faster vs. over a list
         mask_kill=np.zeros([surf.darrays[1].data.shape[0]],dtype=bool) # create empty arrays matching surface mesh dimentions
         mask_keep=mask_kill.copy()
+        """
+        Masks out vertices with intensity=0 from overlay.
+
+        Also returns masked-out vertices.
+
+        Parameters
+        ----------
+        surf: gifti object
+            already loaded gifti object of target surface
+        mask: gifti object
+            already loaded gifti object of overlay with zeroes
+            at vertices of no interest (e.g. medial wall)
+
+        Returns
+        -------
+        mask_keep: np.ndarray
+            Boolean array of what to show.
+        mask_kill: np.ndarray
+            Boolean array of what to hide.
+
+        """
         for ii, row in enumerate(surf.darrays[1].data):
             for item in row:
                 if item in killdict.keys():
@@ -109,31 +132,34 @@ class SurfaceWidget:
                         figlims=np.array([[-100,100],[-100,100],[-100,100]]),
                         showZeroes=True,
                         **kwargs):
-        '''
-            Displays a surface mesh with/without an overlay inside Jupyter notebook for interactive visualization.
+        """
+        Visualise a surface mesh (with overlay) inside notebooks.
 
-            Basic functionality:
-            Read mesh and overlay data
-            Setup the interactive widget
-            Set defaults for plotting
+        Basic functionality:
+        Read mesh and overlay data
+        Setup the interactive widget
+        Set defaults for plotting
 
-            Parameters
-            ----------
-            surface: str, gifti object
-                Path to surface file in gifti or FS surface format or an already loaded gifti object of surface
-            overlay: str, gifti object
-                Path to overlay file in gifti or FS annot or anaotimcal (.curv,.sulc,.thickness) format or an already loaded
-                gifti object of overlay, default None
-            colormap: string
-                A matplotlib colormap, default summer
-            figsize: ndarray
-                Size of the figure to display, default [600,600]
-            figLims: ndarray
-                x,y and z limits of the axes, default [[-100,100],[-100,100],[-100,100]])
-            showZeroes: bool
-                Display vertices with intensity = 0, default True
+        Parameters
+        ----------
+        surface: str, gifti object
+            Path to surface file in gifti or FS surface format or an
+            already loaded gifti object of surface
+        overlay: str, gifti object
+            Path to overlay file in gifti or FS annot or anatomical
+            (.curv,.sulc,.thickness) format or an already loaded
+            gifti object of overlay, default None
+        colormap: string
+            A matplotlib colormap, default summer
+        figsize: ndarray
+            Size of the figure to display, default [600,600]
+        figlims: ndarray
+            x,y and z limits of the axes, default
+            [[-100,100],[-100,100],[-100,100]]
+        show_zeroes: bool
+            Display vertices with intensity = 0, default True
 
-    '''
+        """
         # set default colormap options & add them to the kwargs
         if colormap is None:
             kwargs['colormap'] = ['viridis'] + \

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -3,11 +3,13 @@ from __future__ import print_function
 import nibabel as nb
 import matplotlib.pyplot as plt
 import numpy as np
-from ipywidgets import interact, interactive, fixed, IntSlider
-from ipyvolume import gcf
+from IPython.display import display
+from ipywidgets import interact, fixed, IntSlider
+# from ipyvolume import gcf
 import ipyvolume.pylab as p3
-import ipyvolume.widgets as ipv
 import os
+from pathlib import Path
+
 
 class SurfaceWidget:
     def __init__(self, meshfile, overlayfiles):

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -74,24 +74,23 @@ class SurfaceWidget:
         self.fig = p3.figure(width=figsize[0], height=figsize[1])
         self.fig.camera_fov = 1
         self.fig.style = {'axes': {'color': 'black',
-                     'label': {'color': 'black'},
-                     'ticklabel': {'color': 'black'},
-                     'visible': False},
-                     'background-color': 'white',
-                     'box': {'visible': False}}
+                                   'label': {'color': 'black'},
+                                   'ticklabel': {'color': 'black'},
+                                   'visible': False},
+                          'background-color': 'white',
+                          'box': {'visible': False}}
         self.fig.xlim = (figlims[0][0], figlims[0][1])
         self.fig.ylim = (figlims[1][0], figlims[1][1])
         self.fig.zlim = (figlims[2][0], figlims[2][1])
 
-        # we draw the tetrahedron
-        p3.plot_trisurf(x, y, z, triangles=triangles, color=np.ones((len(x),3)))
-        #p3.show()
+        # draw the tetrahedron
+        p3.plot_trisurf(x, y, z, triangles=triangles,
+                        color=np.ones((len(x), 3)))
 
     def _plot_surface(self, x, y, z, triangles,
                       overlays=None, frame=0,
-                      colormap='summer',
-                      figsize=np.array([600,600]),
-                      figlims=np.array([[-100,100],[-100,100],[-100,100]])):
+                      colormap='summer', figsize=np.array([600, 600]),
+                      figlims=np.array(3 * [[-100, 100]])):
         """
         Visualize/update the overlay.
 

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -30,9 +30,33 @@ class SurfaceWidget:
                       or .gii
 
         """
+        # check meshfile is a valid argument
         self.meshfile = meshfile
-        self.overlayfiles = overlayfiles
-        #self.meshes = None
+        if isinstance(self.meshfile, (str, Path)):
+            # enforce that file is Path object here & also that it exists
+            self.meshfile = Path(self.meshfile).resolve(strict=True)
+        elif isinstance(self.meshfile, nb.gifti.gifti.GiftiImage):
+            pass
+        else:
+            raise TypeError('meshfile needs to be either a path to a valid'
+                            + ' file or a nibabel GiftiImage.')
+
+        # ensure overlayfiles is a list
+        if not isinstance(overlayfiles, (list)):
+            self.overlayfiles = [overlayfiles]
+        else:
+            self.overlayfiles = overlayfiles
+
+        # convert all overlay strings to a path object
+        for i, f in enumerate(self.overlayfiles):
+            if isinstance(f, (str, Path)):
+                self.overlayfiles[i] = Path(f).resolve(strict=True)
+            elif isinstance(f, nb.gifti.gifti.GiftiImage):
+                pass
+            else:
+                raise TypeError('meshfile needs to be either a path to a valid'
+                                + ' file or a nibabel GiftiImage.')
+
         self.fig = None
 
     def _init_figure(self, x, y, z, triangles, figsize, figlims):

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -190,43 +190,32 @@ class SurfaceWidget:
         kwargs['figsize'] = fixed(figsize)
         kwargs['figlims'] = fixed(figlims)
 
-
-        if isinstance(self.meshfile,str):
-            if not os.path.exists(self.meshfile):
-                raise IOError('File does not exist, please provide a valid file path to a gifti or FreeSurfer file.')
-            filename, file_extension = os.path.splitext(self.meshfile)
-            if file_extension is '.gii':
-                mesh = nb.load(self.meshfile)
+        if isinstance(self.meshfile, Path):
+            # if mesh has not been loaded before, load it
+            if self.meshfile.suffix == '.gii':
+                # load gifti file
+                self.meshfile = nb.load(self.meshfile)
                 try:
-                    vertex_spatial=mesh.darrays[0].data
-                    vertex_edges=mesh.darrays[1].data
+                    vertex_spatial = self.meshfile.darrays[0].data
+                    vertex_edges = self.meshfile.darrays[1].data
                     x, y, z = vertex_spatial.T
                 except:
                     raise ValueError('Please provide a valid gifti file.')
             else:
+                # load freesurfer file
                 fsgeometry = nb.freesurfer.read_geometry(self.meshfile)
-                x,y,z = fsgeometry[0].T
-                vertex_edges=fsgeometry[1]
+                x, y, z = fsgeometry[0].T
+                vertex_edges = fsgeometry[1]
 
-        if isinstance(self.meshfile,nb.gifti.gifti.GiftiImage):
+        elif isinstance(self.meshfile, nb.gifti.gifti.GiftiImage):
+            # if mesh has been loaded as a GiftiImage, format the data
             try:
-                vertex_spatial=self.meshfile.darrays[0].data
-                vertex_edges=self.meshfile.darrays[1].data
+                vertex_spatial = self.meshfile.darrays[0].data
+                vertex_edges = self.meshfile.darrays[1].data
                 x, y, z = vertex_spatial.T
             except:
                 raise ValueError('Please provide a valid gifti file.')
 
-        if isinstance(self.overlayfiles,list):
-            max_frame = len(self.overlayfiles)-1
-        else:
-            max_frame = 0
-            self.overlayfiles = [self.overlayfiles] # hack
-
-        overlays = np.zeros((len(x),len(self.overlayfiles)))
-        for ii, overlayfile in enumerate(self.overlayfiles):
-            if isinstance(overlayfile,str):
-                if not os.path.exists(overlayfile):
-                    raise IOError('File does not exist, please provide a valid file path to a gifti or FreeSurfer file.')
         if len(self.overlayfiles) > 0:
             overlays = np.zeros((len(x), len(self.overlayfiles)))
             for i, overlayfile in enumerate(self.overlayfiles):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+"""Installer."""
+from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -23,10 +24,12 @@ setup(
     author='Bjoern Soergel & Jan Freyberg',
     author_email='jan.freyberg@gmail.com',
     packages=['niwidgets'],
-    keywords = ['widgets', 'neuroimaging'],
+    keywords=['widgets', 'neuroimaging'],
     install_requires=['ipywidgets', 'nilearn', 'nibabel', 'ipyvolume'],
     # Include the template file
     package_data={
-        '': ['data/*nii*','data/examples_surfaces/lh.*','data/examples_surfaces/*.ctab']
+        '': ['data/*nii*',
+             'data/examples_surfaces/lh.*',
+             'data/examples_surfaces/*.ctab']
     },
 )


### PR DESCRIPTION
- Made the code mostly pep8 compliant
- added checks for file path validity upfront
- added automatic drawing of the surface widget
- made it so you don't have to pass any overlay files if you don't want to
- removed some division warnings
- commented out the zmask stuff - as far as I could tell it's not being used at the moment, this should be fixed at some point