### PR TITLE
Addressing bugs raised recently

### DIFF
--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -44,7 +44,9 @@ class SurfaceWidget:
         self.meshfile = meshfile
         if isinstance(self.meshfile, (str, Path)):
             # enforce that file is Path object here & also that it exists
-            self.meshfile = Path(self.meshfile).resolve(strict=True)
+            self.meshfile = Path(self.meshfile).resolve()
+            if not os.path.isfile(self.meshfile):
+                raise OSError('File ' + self.meshfile.name + ' not found.')
         elif isinstance(self.meshfile, nb.gifti.gifti.GiftiImage):
             pass
         else:
@@ -60,7 +62,10 @@ class SurfaceWidget:
         # convert all overlay strings to a path object
         for i, f in enumerate(self.overlayfiles):
             if isinstance(f, (str, Path)):
-                self.overlayfiles[i] = Path(f).resolve(strict=True)
+                self.overlayfiles[i] = Path(f).resolve()
+                if not os.path.isfile(self.overlayfiles[i]):
+                    raise OSError('File ' + self.overlayfiles[i].name
+                                  + ' not found.')
             elif isinstance(f, nb.gifti.gifti.GiftiImage):
                 pass
             else:

--- a/niwidgets/niwidget_volume.py
+++ b/niwidgets/niwidget_volume.py
@@ -96,7 +96,7 @@ class NiftiWidget:
         else:
             self._custom_plotter(plotting_func, **kwargs)
 
-    def _default_plotter(self, mask_background=True, **kwargs):
+    def _default_plotter(self, mask_background=False, **kwargs):
         """
         Plot three orthogonal views.
 
@@ -113,6 +113,8 @@ class NiftiWidget:
 
         # mask the background
         if mask_background:
+            # TODO: add the ability to pass 'mne' to use a default brain mask
+            # TODO: split this out into a different function
             if data_array.ndim == 3:
                 labels, n_labels = scipy.ndimage.measurements.label(
                                             (np.round(data_array) == 0))

--- a/niwidgets/niwidget_volume.py
+++ b/niwidgets/niwidget_volume.py
@@ -5,6 +5,7 @@ import numpy as np
 from ipywidgets import interact, fixed, IntSlider
 import inspect
 import scipy.ndimage
+import os
 
 # import pathlib & backwards compatibility
 try:
@@ -40,7 +41,9 @@ class NiftiWidget:
                     The path to your ``.nii`` file. Can be a string, or a
                     ``PosixPath`` from python3's pathlib.
         """
-        self.filename = Path(filename).resolve(strict=True)
+        self.filename = Path(filename).resolve()
+        if not os.path.isfile(self.filename):
+            raise OSError('File ' + self.filename.name + ' not found.')
 
         # load data in advance
         # this ensures once the widget is created that the file is of a format


### PR DESCRIPTION
- The "automatic" background masking means some images become completely washed out, so I've set it to be disabled for now.
- checking if a file exists has been split from the `path.resolve(strict=True)` method and is now done explicitly. This means it now works on python <3.6
