### PR TITLE
ENH/niwidget_volume.py- delete os import

### DIFF
--- a/niwidgets/niwidget_volume.py
+++ b/niwidgets/niwidget_volume.py
@@ -5,7 +5,6 @@ import numpy as np
 from ipywidgets import interact, fixed, IntSlider
 import inspect
 import scipy.ndimage
-import os
 
 # import pathlib & backwards compatibility
 try:
@@ -45,7 +44,7 @@ class NiftiWidget:
             self.data = filename
         else:
             filename = Path(filename).resolve()
-            if not os.path.isfile(filename):
+            if not filename.is_file():
                 raise OSError('File ' + filename.name + ' not found.')
 
             # load data in advance


### PR DESCRIPTION
os was imported for use of os.path.isfile(), however since we're using pathlib.Path objects, we can simply check with Path.is_file(), since this was the only reason os was imported, we can get rid of the import entirely