### PR TITLE
Various fixes for Python 2 compatibility

### DIFF
--- a/niwidgets/exampledata.py
+++ b/niwidgets/exampledata.py
@@ -3,7 +3,7 @@
 try:
     # on >3 this ships by default
     from pathlib import Path
-except ModuleNotFoundError:
+except ImportError:
     # on 2.7 this should work
     try:
         from pathlib2 import Path

--- a/niwidgets/niwidget_surface.py
+++ b/niwidgets/niwidget_surface.py
@@ -12,7 +12,7 @@ import os
 try:
     # on >3 this ships by default
     from pathlib import Path
-except ModuleNotFoundError:
+except ImportError:
     # on 2.7 this should work
     try:
         from pathlib2 import Path

--- a/niwidgets/niwidget_volume.py
+++ b/niwidgets/niwidget_volume.py
@@ -10,13 +10,13 @@ import scipy.ndimage
 try:
     # on >3 this ships by default
     from pathlib import Path
-except ModuleNotFoundError:
+except ImportError:
     # on 2.7 this should work
     try:
         from pathlib2 import Path
-    except ModuleNotFoundError:
-        raise ModuleNotFoundError('On python 2.7, niwidgets requires '
-                                  'pathlib2 to be installed.')
+    except ImportError:
+        raise ImportError('On python 2.7, niwidgets requires '
+                          'pathlib2 to be installed.')
 
 
 class NiftiWidget:
@@ -43,7 +43,6 @@ class NiftiWidget:
         if hasattr(filename, 'get_data'):
             self.data = filename
         else:
-            filename = Path(filename).resolve()
             if not filename.is_file():
                 raise OSError('File ' + filename.name + ' not found.')
 


### PR DESCRIPTION
This PR fixes Python 2 compatibility.

It is dependent on this Py2 compatibility fix in ipyvolume: https://github.com/maartenbreddels/ipyvolume/pull/103

Also I'm not sure how to fix the following line elegantly:

https://github.com/nipy/niwidgets/compare/master...lrq3000:py2fix?expand=1#diff-c4e3c3c90dfe314c2eaad3135f7992d4L46

But in any case, in Python 2, os.stat() and thus os.file.exists() expect a str, not a Path object. Maybe we can do a branching depending on Python 2 or Python 3?