### PR TITLE
fix: installation

### DIFF
--- a/niwidgets/__init__.py
+++ b/niwidgets/__init__.py
@@ -4,6 +4,7 @@ Widgets to visualise neuroimaging data.
 For volume images, try import NiftiWidget.
 For surface images, try SurfaceWidget.
 """
+from .version import __version__
 from .exampledata import exampleatlas, examplezmap, examplet1  # noqa: F401
 from .niwidget_volume import NiftiWidget  # noqa: F401
 from .niwidget_surface import SurfaceWidget  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,14 @@ from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 import os.path
-from niwidgets.version import version
 
 here = os.path.dirname(os.path.abspath(__file__))
+ver_file = os.path.join(here, 'niwidgets', 'version.py')
 
-version_ns = {}
-with open(os.path.join(here, 'niwidgets', 'version.py')) as f:
-    exec(f.read(), {}, version_ns)
+with open(ver_file) as f:
+    exec(f.read(), globals(), locals())
 
-# version = version_ns['version']
+version = locals()['__version__']
 
 blurb = 'A package that provides ipywidgets for standard neuroimaging plotting'
 


### PR DESCRIPTION
importing from `niwidgets.version` detoured into `__init__.py` and attempted to import dependencies before setuptools installed them.

this patch should allow installation on a fresh environment