### PR TITLE
update path to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ different overlays for the surface files.
 using `ipyvolume`.
 
 To see how to use these widgets, please check the
-[documentation](nipy.org/niwidgets).
+[documentation](https://nipy.org/niwidgets).
 
 As an example of how you might generate a Volume widget:
 


### PR DESCRIPTION
Otherwise, prefix of the github is used resulting in:
```
https://github.com/nipy/niwidgets/blob/master/nipy.org/niwidgets
```