### PR TITLE
Tiny numpy FutureWarning fix for multidimenstional array indexing

### DIFF
--- a/src/niwidgets/niwidget_volume.py
+++ b/src/niwidgets/niwidget_volume.py
@@ -192,9 +192,9 @@ class NiftiWidget:
 
             # update the image
             imh.set_data(
-                np.flipud(np.rot90(data[slice_obj], k=1))
+                np.flipud(np.rot90(data[tuple(slice_obj)], k=1))
                 if views[ii] != "Sagittal"
-                else np.fliplr(np.flipud(np.rot90(data[slice_obj], k=1)))
+                else np.fliplr(np.flipud(np.rot90(data[tuple(slice_obj)], k=1)))
             )
 
             # draw guides to show selected coordinates

--- a/src/niwidgets/niwidget_volume.py
+++ b/src/niwidgets/niwidget_volume.py
@@ -194,7 +194,9 @@ class NiftiWidget:
             imh.set_data(
                 np.flipud(np.rot90(data[tuple(slice_obj)], k=1))
                 if views[ii] != "Sagittal"
-                else np.fliplr(np.flipud(np.rot90(data[tuple(slice_obj)], k=1)))
+                else np.fliplr(
+                    np.flipud(np.rot90(data[tuple(slice_obj)], k=1))
+                )
             )
 
             # draw guides to show selected coordinates


### PR DESCRIPTION
Changed 'slice_obj' to 'tuple(slice_obj)' when used to index the multidimensional 'data' array. This is meant to both comply with future numpy versions and silence the FutureWarning that is currently displayed. Resolves #58.